### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/hardchor/timesheets.png?label=ready&title=Ready)](https://waffle.io/hardchor/timesheets)
 # electron-react-boilerplate
 
 [![NPM version][npm-image]][npm-url]


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/hardchor/timesheets

This was requested by a real person (user hardchor) on waffle.io, we're not trying to spam you.
